### PR TITLE
feature: Added auditing feature by implementing BaseEntity and BaseTi…

### DIFF
--- a/server/src/main/java/com/example/spring_websocket/chatroom/ChatRoom.java
+++ b/server/src/main/java/com/example/spring_websocket/chatroom/ChatRoom.java
@@ -1,5 +1,6 @@
 package com.example.spring_websocket.chatroom;
 
+import com.example.spring_websocket.global.audit.BaseEntity;
 import com.example.spring_websocket.memberchatroom.MemberChatRoom;
 import com.example.spring_websocket.member.Member;
 import jakarta.persistence.*;
@@ -13,7 +14,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatRoom {
+public class ChatRoom extends BaseEntity {
     @Id
     @GeneratedValue
     private Long id;

--- a/server/src/main/java/com/example/spring_websocket/global/audit/AuditConfig.java
+++ b/server/src/main/java/com/example/spring_websocket/global/audit/AuditConfig.java
@@ -1,0 +1,17 @@
+package com.example.spring_websocket.global.audit;
+
+import com.example.spring_websocket.member.Member;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditConfig {
+
+    @Bean
+    public AuditorAware<Member> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/server/src/main/java/com/example/spring_websocket/global/audit/AuditorAwareImpl.java
+++ b/server/src/main/java/com/example/spring_websocket/global/audit/AuditorAwareImpl.java
@@ -1,0 +1,14 @@
+package com.example.spring_websocket.global.audit;
+
+import com.example.spring_websocket.member.Member;
+import org.springframework.data.domain.AuditorAware;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl implements AuditorAware<Member> {
+
+    @Override
+    public Optional<Member> getCurrentAuditor() {
+        return Optional.empty();
+    }
+}

--- a/server/src/main/java/com/example/spring_websocket/global/audit/BaseEntity.java
+++ b/server/src/main/java/com/example/spring_websocket/global/audit/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.example.spring_websocket.global.audit;
+
+import com.example.spring_websocket.member.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity extends BaseTimeEntity {
+    @CreatedBy
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private Member createdBy;
+
+    @LastModifiedBy
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "last_modified_by")
+    private Member lastModifiedBy;
+}

--- a/server/src/main/java/com/example/spring_websocket/global/audit/BaseTimeEntity.java
+++ b/server/src/main/java/com/example/spring_websocket/global/audit/BaseTimeEntity.java
@@ -1,0 +1,19 @@
+package com.example.spring_websocket.global.audit;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @CreatedDate
+    private LocalDateTime lastModifiedAt;
+}

--- a/server/src/main/java/com/example/spring_websocket/member/Member.java
+++ b/server/src/main/java/com/example/spring_websocket/member/Member.java
@@ -1,5 +1,6 @@
 package com.example.spring_websocket.member;
 
+import com.example.spring_websocket.global.audit.BaseEntity;
 import com.example.spring_websocket.memberchatroom.MemberChatRoom;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -15,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-public class Member {
+public class Member extends BaseEntity {
     @Id
     @GeneratedValue
     private Long id;

--- a/server/src/main/java/com/example/spring_websocket/member/dto/response/MemberResponseDto.java
+++ b/server/src/main/java/com/example/spring_websocket/member/dto/response/MemberResponseDto.java
@@ -3,13 +3,19 @@ package com.example.spring_websocket.member.dto.response;
 import com.example.spring_websocket.member.Member;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Data
 public class MemberResponseDto {
     private Long id;
     private String nickname;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastModifiedAt;
 
     public MemberResponseDto(Member member) {
         this.id = member.getId();
         this.nickname = member.getNickname();
+        this.createdAt = member.getCreatedAt();
+        this.lastModifiedAt = member.getLastModifiedAt();
     }
 }

--- a/server/src/main/java/com/example/spring_websocket/memberchatroom/MemberChatRoom.java
+++ b/server/src/main/java/com/example/spring_websocket/memberchatroom/MemberChatRoom.java
@@ -1,6 +1,7 @@
 package com.example.spring_websocket.memberchatroom;
 
 import com.example.spring_websocket.chatroom.ChatRoom;
+import com.example.spring_websocket.global.audit.BaseEntity;
 import com.example.spring_websocket.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,7 +11,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberChatRoom {
+public class MemberChatRoom extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/server/src/main/java/com/example/spring_websocket/message/MessageController.java
+++ b/server/src/main/java/com/example/spring_websocket/message/MessageController.java
@@ -1,12 +1,9 @@
 package com.example.spring_websocket.message;
 
 import com.example.spring_websocket.message.dto.MessageRequestDto;
-import com.example.spring_websocket.message.dto.MessageResponseDto;
-import com.example.spring_websocket.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
@@ -14,14 +11,7 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class MessageController {
 
-    private final ChatService chatService;
     private final MessageService messageService;
-
-    @MessageMapping("/chat")
-    @SendTo("/topic/chat")
-    public MessageResponseDto sendChatMessage(MessageRequestDto requestDto, SimpMessageHeaderAccessor accessor) {
-        return chatService.processMessage(requestDto, accessor.getSessionId(), (String) accessor.getSessionAttributes().get("nickname"));
-    }
 
     @MessageMapping("/chat-rooms/{chatRoomId}")
     public void sendChatMessage(MessageRequestDto requestDto, SimpMessageHeaderAccessor accessor, @DestinationVariable Long chatRoomId) {

--- a/server/src/main/java/com/example/spring_websocket/message/domain/Message.java
+++ b/server/src/main/java/com/example/spring_websocket/message/domain/Message.java
@@ -1,6 +1,7 @@
 package com.example.spring_websocket.message.domain;
 
 import com.example.spring_websocket.chatroom.ChatRoom;
+import com.example.spring_websocket.global.audit.BaseEntity;
 import com.example.spring_websocket.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-public class Message {
+public class Message extends BaseEntity {
     @Id
     @GeneratedValue
     private Long id;

--- a/server/src/test/java/com/example/spring_websocket/service/MemberServiceTest.java
+++ b/server/src/test/java/com/example/spring_websocket/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import com.example.spring_websocket.chatroom.ChatRoomRepository;
 import com.example.spring_websocket.memberchatroom.MemberChatRoomRepository;
 import com.example.spring_websocket.member.MemberRepository;
 import com.example.spring_websocket.global.JwtTokenProvider;
+import com.example.spring_websocket.message.MessageService;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +35,8 @@ class MemberServiceTest {
     private MemberChatRoomRepository memberChatRoomRepository;
     @Mock
     private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private MessageService messageService;
 
     @InjectMocks
     private MemberService memberService;
@@ -43,7 +46,7 @@ class MemberServiceTest {
         // given
         String nickname = "nickname";
 
-        Member mockMember = Mockito.mock(Member.class);
+        Member mockMember = mock(Member.class);
         when(mockMember.getId()).thenReturn(1L);
         when(memberRepository.save(any(Member.class))).thenReturn(mockMember);
         when(jwtTokenProvider.createToken(any(String.class))).thenReturn("accessToken");


### PR DESCRIPTION
## 변경 사항
- global/audit 패키지 추가
- 글로벌 Auditing을 위한 BaseEntity와 BaseTimeEntity 추가
- JPA Auditing 사용에 필요한 AuditConfig와 AuditorAwareImpl 추가
- BaseEntity의 createdBy와 lastModifiedBy를 Member로 구현(연관관계 포함)
- AuditorAwareImpl은 Optional.empty()를 반환하도록 임시 구현

## 추가 고려 사항 및 주의 사항
- createdBy와 lastModifiedBy의 Auditing을 위한 구현 필요
- 임시로 구현된 AccessToken 검증과 통합된 인증/인가 제공을 위한 Spring Security 도입 고려
- 시스템에 의해 생성되는 경우(Member 등) 시스템을 의미하는 Member 필요한지 아니면 null로 남길 것인지 고려 (그래도 null은 좀 그렇지 않나)
- Message 같은 경우 보낸 사람이 createdBy 인가? Auditing을 비즈니스 로직에 포함시켜도 되는가? 아니면 sender_id(혹은 Member sentBy)가 서로 별개로 존재해야 하는가? 애초에 남이 나로 메시지를 보낼 수 있는가? 아니면 그걸 확인할 수 있게 하는게 Auditing의 역할인가?

## 테스트 스크린샷

<img width="539" alt="image" src="https://github.com/user-attachments/assets/f7ec5e27-b263-44ce-9989-bb0d39a9491c" />
