### PR TITLE
fix: Navigate to Join when STOMP connection error or disconnect

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,26 +1,35 @@
 import {useEffect} from "react";
 import {Outlet, useNavigate} from "react-router";
 import {useStore} from "./store/store.ts";
+import {useStomp} from "./hooks/useStomp.ts";
 
 function App() {
   const navigate = useNavigate();
-  const {accessToken, setAccessToken} = useStore();
+  const {accessToken, stompClient} = useStore();
+  const {connect} = useStomp();
   
   useEffect(() => {
-    const localAccessToken = localStorage.getItem("accessToken");
-    
-    if (!localAccessToken) {
+    if (!accessToken) {
       navigate("/join");
       return;
     }
-
-    if (!accessToken) {
-      setAccessToken(localAccessToken);
+    
+    if (stompClient && stompClient.connected) {
+      return;
     }
 
-    navigate("/chat-rooms");
+    connect({
+      accessToken: accessToken,
+      onConnect: () => {},
+      onError: () => {
+        navigate("/join");
+      },
+      onDisconnect: () => {
+        navigate("/join");
+      }
+    })
 
-  }, []);
+  }, [accessToken, navigate, stompClient?.connected]);
   
   return (
       <Outlet/>

--- a/client/src/hooks/useStomp.ts
+++ b/client/src/hooks/useStomp.ts
@@ -1,0 +1,51 @@
+import {useCallback} from "react";
+import {useStore} from "../store/store.ts";
+import {SOCKET_URL} from "../config.ts";
+import SockJS from "sockjs-client";
+import {Client, IFrame} from "@stomp/stompjs";
+
+interface ConnectOptions {
+    accessToken: string;
+    onConnect: () => void;
+    onError: (e: IFrame) => void;
+    onDisconnect: () => void;
+}
+
+export function useStomp() {
+    const {setStompClient} = useStore();
+
+    const connect = useCallback(
+        ({
+             accessToken,
+             onConnect,
+             onError,
+             onDisconnect
+         }: ConnectOptions) => {
+            const socket = new SockJS(SOCKET_URL);
+
+            const stompClient = new Client({
+                webSocketFactory: () => socket,
+                debug: (msg: string) => console.log("[STOMP]:", msg),
+                connectHeaders: {
+                    accessToken: accessToken,
+                },
+                onConnect: () => onConnect(),
+                onStompError: (e) => {
+                    console.error("[STOMP] 연결 실패: ", e);
+                    onError(e);
+                },
+                onDisconnect: () => onDisconnect(),
+                reconnectDelay: 5000,
+                heartbeatIncoming: 4000,
+                heartbeatOutgoing: 4000,
+            });
+
+            stompClient.activate();
+            setStompClient(stompClient);
+        }, [setStompClient]
+    );
+
+    return {
+        connect
+    };
+}

--- a/client/src/pages/ChatRooms.tsx
+++ b/client/src/pages/ChatRooms.tsx
@@ -1,9 +1,6 @@
 import {useStore} from "../store/store.ts";
 import {useNavigate} from "react-router";
 import {useEffect, useState} from "react";
-import SockJS from "sockjs-client";
-import {SOCKET_URL} from "../config.ts";
-import {Client} from "@stomp/stompjs";
 import api from "../api/api.ts";
 import {ChatRoomsResponseDto} from "../api/dtos/response/ChatRoomsResponseDto.ts";
 import {ChatRoomResponseDto} from "../api/dtos/response/ChatRoomResponseDto.ts";
@@ -11,36 +8,8 @@ import ChatRoomItem from "../components/ChatRoomItem.tsx";
 
 export default function ChatRooms() {
     const [chatRooms, setChatRooms] = useState<ChatRoomResponseDto[]>();
-    const {accessToken, setStompClient} = useStore()
+    const {accessToken} = useStore()
     const navigate = useNavigate();
-
-    useEffect(() => {
-        if (!accessToken) {
-            navigate("/");
-            return;
-        }
-
-        const socket = new SockJS(SOCKET_URL);
-        const stompClient = new Client({
-            webSocketFactory: () => socket,
-            debug: (msg: string) => console.log("[STOMP]:", msg),
-            connectHeaders: {
-                accessToken: accessToken,
-            },
-            onStompError: (e) => {
-                console.error("[STOMP] 연결 실패: ", e);
-                stompClient.deactivate();
-            },
-            onDisconnect: () => console.log("STOMP 연결 해제"),
-            reconnectDelay: 5000,
-            heartbeatIncoming: 4000,
-            heartbeatOutgoing: 4000,
-        });
-
-        stompClient.activate();
-        setStompClient(stompClient);
-
-    }, [accessToken, navigate, setStompClient]);
 
     useEffect(() => {
         if (!accessToken) return;

--- a/client/src/pages/Join.tsx
+++ b/client/src/pages/Join.tsx
@@ -23,7 +23,6 @@ export default function Join() {
         if (response.status === 200) {
             setAccessToken(response.data.accessToken);
             setMemberId(response.data.memberId);
-            localStorage.setItem("accessToken", response.data.accessToken);
             navigate("/chat-rooms");
         }
     };

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -16,5 +16,5 @@ export const useStore = create<StoreState>((set) => ({
     stompClient: null,
     setStompClient: (stompClient) => set({stompClient}),
     memberId: null,
-    setMemberId: (memberId) => set({memberId})
+    setMemberId: (memberId) => set({memberId}),
 }))

--- a/server/src/main/java/com/example/spring_websocket/websocket/MyChannelInterceptor.java
+++ b/server/src/main/java/com/example/spring_websocket/websocket/MyChannelInterceptor.java
@@ -1,6 +1,8 @@
 package com.example.spring_websocket.websocket;
 
 import com.example.spring_websocket.global.JwtTokenProvider;
+import com.example.spring_websocket.member.MemberRepository;
+import com.example.spring_websocket.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -13,6 +15,7 @@ import org.springframework.messaging.support.ChannelInterceptor;
 public class MyChannelInterceptor implements ChannelInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -41,6 +44,11 @@ public class MyChannelInterceptor implements ChannelInterceptor {
         }
 
         Long memberId = jwtTokenProvider.getMemberIdFromToken(accessToken);
+
+        if (!memberRepository.existsById(memberId)) {
+            throw new IllegalStateException("Invalid memberId");
+        }
+
         accessor.getSessionAttributes().put("memberId", memberId);
     }
 }

--- a/server/src/main/java/com/example/spring_websocket/websocket/WebSocketConfig.java
+++ b/server/src/main/java/com/example/spring_websocket/websocket/WebSocketConfig.java
@@ -1,6 +1,8 @@
 package com.example.spring_websocket.websocket;
 
 import com.example.spring_websocket.global.JwtTokenProvider;
+import com.example.spring_websocket.member.MemberRepository;
+import com.example.spring_websocket.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -15,6 +17,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -31,6 +34,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(new MyChannelInterceptor(jwtTokenProvider));
+        registration.interceptors(new MyChannelInterceptor(jwtTokenProvider, memberRepository));
     }
 }


### PR DESCRIPTION
## 변경 사항

- STOMP 연결을 useStomp.ts 커스텀 훅으로 리펙토링.
- STOMP 연결시 useStomp의 connect 호출.
- 호출 시에 매개변수로 accessToken, onConnect(), onError(), onDisconnect()를 전달하도록 구현.
- App.tsx("/")에서 stompClient가 없는 경우 최초 연결하도록 수정.
- onError와 onDisconnect로 STOMP 연결에 문제 발생시 "/join"으로 이동하도록 구현.
- stompClient가 필요한 나머지 라우트는 App.tsx 내부 Outlet에 렌더링 되도록 중첩 라우팅 구현.

## 고려 사항 및 주의 사항
- stomp 연결 해제 시에만 채팅방을 나가도록 구현되어 있어서, 뒤로가기로 채팅방을 벗어나는 경우 채팅방을 나가지 않은 것으로 처리 됨. -> 추가 이슈로 처리 예정.

## 관련 이슈
- #14 